### PR TITLE
fix/search-query-with-paging-returns-empty-final-page

### DIFF
--- a/osdu/search.py
+++ b/osdu/search.py
@@ -40,7 +40,7 @@ class SearchService(BaseService):
                         the Lucene syntax suported by OSDU. For more details, see: 
                         https://community.opengroup.org/osdu/documentation/-/wikis/Releases/R2.0/OSDU-Query-Syntax
 
-        :returns:       iterator containing  items: results, totalCount
+        :returns:       iterator of tuple containing 2 items: (results, totalCount)
                         - results:      list:   one page of records resutling from search query. Default page size
                                                 is 10. This can be modified by passing the 'limit' parameter in
                                                 query with the maximum allowed being 1000.

--- a/osdu/search.py
+++ b/osdu/search.py
@@ -12,7 +12,7 @@ class SearchService(BaseService):
 
 
     def query(self, query: dict) -> dict:
-        """
+        """Executes a query against the OSDU search service.
 
         :param query:   dict representing the JSON-style query to be sent to the search API. Must adhere to
                         the Lucene syntax suported by OSDU. For more details, see: 
@@ -33,20 +33,37 @@ class SearchService(BaseService):
 
 
     def query_with_paging(self, query: dict):
+        """Executes a query with cursor against the OSDU search service. Returns a generator, which can than be
+        iterated over to retrieve each page in the result set without having to deal with any cursor.
+
+        :param query:   dict representing the JSON-style query to be sent to the search API. Must adhere to
+                        the Lucene syntax suported by OSDU. For more details, see: 
+                        https://community.opengroup.org/osdu/documentation/-/wikis/Releases/R2.0/OSDU-Query-Syntax
+
+        :returns:       iterator containing  items: results, totalCount
+                        - results:      list:   one page of records resutling from search query. Default page size
+                                                is 10. This can be modified by passing the 'limit' parameter in
+                                                query with the maximum allowed being 1000.
+                        - totalCount:   int:    the total number of results despite any 'limit' specified in the
+                                                query or the 1,000 record limit of the API
+        """
         url = f'{self._service_url}/query_with_cursor'
-        cursor='initial'
+        cursor=''
 
         try:
             while cursor:
                 # Add cursor to request body for subsequent requests.
-                if cursor != "initial":
-                    query["cursor"] = cursor
+                if cursor != '':
+                    query['cursor'] = cursor
                 
                 response = requests.post(url=url, headers=self._headers(), json=query)
                 response.raise_for_status()
 
                 cursor, results, total_count  = response.json().values()
-                yield results, total_count
+                if not cursor:  # Effetive do-while condition
+                    break
+                else:
+                    yield results, total_count
 
         except requests.exceptions.HTTPError as e:
             logging.error(e)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -58,7 +58,6 @@ class TestSearchService_Query(TestOsduServiceBase):
 
 
     def test_get_all_wellbores(self):
-        #Get Wellbores
         query = {
             "kind": "opendes:osdu:*:0.2.0",
             "query": "data.ResourceTypeID:\"srn:type:master-data/Wellbore:\""
@@ -204,6 +203,20 @@ class TestSearchService_QueryWithPaging(TestOsduServiceBase):
             if page_count >= max_pages:
                 break
 
+    def test_paging_gets_all_results(self):
+        page_size = 1000
+        query = {
+            'kind': 'opendes:osdu:well-master:*',
+            'limit': page_size
+        }
+        result = self.osdu.search.query_with_paging(query)
+
+        record_count = 0
+        total_count = 0
+        for page, total in result:
+            total_count = total
+            record_count += len(page)
+        self.assertEqual(total_count, record_count)
 
 class TestStorageService(TestOsduServiceBase):
 


### PR DESCRIPTION
Fixed bug in search.query_with_paging where an additional final empy page.